### PR TITLE
Prevent textlayer names from being renamed by Sketch after editing

### DIFF
--- a/Rename It.sketchplugin/Contents/Sketch/findReplace.sketchscript
+++ b/Rename It.sketchplugin/Contents/Sketch/findReplace.sketchscript
@@ -56,6 +56,9 @@ var findReplace = function(context) {
         var layer = selection[i];
         var name = replaceText([layer name], i, options.findText, options.replaceWith, doc);
         [layer setName:name];
+		
+		// Prevent textlayer name from being renamed after editing
+		layer.nameIsFixed = 1;
 
     	// Success message
     	[doc showMessage: "Rename it: Updated "+selectionCount+" layer(s)"];

--- a/Rename It.sketchplugin/Contents/Sketch/manifest.json
+++ b/Rename It.sketchplugin/Contents/Sketch/manifest.json
@@ -3,7 +3,7 @@
   "description": "Sketch plugin to rename layers like a boss.",
   "author": "Rodrigo Soares",
   "homepage": "https://github.com/rodi01/RenameIt",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "identifier": "ninja.taptap.rename-it",
   "compatibleVersion": "3.3.2",
   "bundleVersion": 1,

--- a/Rename It.sketchplugin/Contents/Sketch/renameIt.sketchscript
+++ b/Rename It.sketchplugin/Contents/Sketch/renameIt.sketchscript
@@ -139,6 +139,9 @@ var renameSelectedLayers = function(context) {
             height = [frame height];
         var name = rename([layer name], i, width, height, selectionCount, options.basename, options.startsFrom);
         [layer setName:name];
+		
+		// Prevent textlayer name from being renamed after editing
+		layer.nameIsFixed = 1;
 
     // Success message
         [doc showMessage: "Rename it: Updated "+selectionCount+" layer(s)"];


### PR DESCRIPTION
Hi Rodrigo,

Thanks for this very helpful script. I use it all the time. I've added a small change to prevent text layernames that have been set by RenameIt get overwritten by Sketch after updating a textlayers value.

Best,
Andre