### PR TITLE
Suggest new layer names based on common pattern

### DIFF
--- a/Rename It.sketchplugin/Contents/Sketch/renameIt.sketchscript
+++ b/Rename It.sketchplugin/Contents/Sketch/renameIt.sketchscript
@@ -87,8 +87,7 @@ function paddy(n, p, c) {
 }
 
 
-function createDialog(selection)
-{
+function createDialog(selection, suggestedName) {
 	var alert = COSAlertWindow.new();
 
 	function createTextFieldWithLabel(label,defaultValue) {
@@ -103,7 +102,7 @@ function createDialog(selection)
 	alert.setInformativeText("Helpers: \nNumber Sequence: %N Descending | %n Ascending \nDimensions: %W %H \nMove Original Layer Name: *");
 
 	// Name
-	createTextFieldWithLabel("Name:","");
+	createTextFieldWithLabel("Name:", suggestedName);
 	var firstField = alert.viewAtIndex(1)
 
 	// Interator
@@ -143,6 +142,45 @@ function handleAlertResponse(alert, responseCode) {
 		return null;
 }
 
+function getNames(layers) {
+	var names = [];
+	var l = layers.count();
+
+	while (l--) {
+		names[l] = layers[l].name();
+	}
+	return names;
+}
+
+function sortStrings(array) {
+	var clone = [NSMutableArray arrayWithArray:array];
+	return clone.sort();
+}
+
+function findCommonPrefix(array) {
+	var sorted = sortStrings(array);
+	var first = sorted[0];
+	var last = sorted.lastObject();
+
+	if (first == last) {
+		return first;
+	}
+
+	var length = first.length();
+	var i = 0;
+
+	while (i < length && first.charAt(i) == last.charAt(i)) {
+		i++;
+	}
+	return first.substring(0, i);
+}
+
+function findSuggestedName(layers) {
+	var names = getNames(layers);
+	var common = findCommonPrefix(names);
+	return !common ? "" : (common.trim() + " %n");
+}
+
 // Run
 var renameSelectedObjects = function(context, selection) {
 	var selectionCount = [selection count]
@@ -150,7 +188,7 @@ var renameSelectedObjects = function(context, selection) {
   if (selectionCount > 0)
   {
 		// Show dialog
-		var alert = createDialog(selection);
+		var alert = createDialog(selection, findSuggestedName(selection));
 		var options=handleAlertResponse(alert,alert.runModal());
 		if (!isInt(options.startsFrom)) options.startsFrom = 1;
 


### PR DESCRIPTION
**▶️ [See the changes in action](https://imgur.com/a/YPMH7)**

Added a couple lines of code for suggesting a layer name based on selection. It’s something I find myself doing manually over and over again. The choice of `%n` may seem a little opinionated, but it’s possible that others will find it useful, too.

The plugin only handles prefixes at the moment, but can be extended to suffixes and more general patterns in the future, too.

Let me know what you think.